### PR TITLE
updated configuration

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -13,10 +13,13 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $tree = new TreeBuilder();
-        $tree->root('intaro_postgres_search')
-            ->end();
+        $tree = new TreeBuilder('intaro_postgres_search');
 
-        return $tree;
+        // Keep compatibility with symfony/config < 4.2
+        if (!method_exists($tree, 'getRootNode')) {
+            return $tree->root('jms_translation')->end();
+        } else {
+            return $tree->getRootNode()->end();
+        }
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,7 +17,7 @@ class Configuration implements ConfigurationInterface
 
         // Keep compatibility with symfony/config < 4.2
         if (!method_exists($tree, 'getRootNode')) {
-            return $tree->root('jms_translation')->end();
+            return $tree->root('intaro_postgres_search')->end();
         } else {
             return $tree->getRootNode()->end();
         }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,9 +17,11 @@ class Configuration implements ConfigurationInterface
 
         // Keep compatibility with symfony/config < 4.2
         if (!method_exists($tree, 'getRootNode')) {
-            return $tree->root('intaro_postgres_search')->end();
+            $tree->root('intaro_postgres_search')->end();
         } else {
-            return $tree->getRootNode()->end();
+            $tree->getRootNode()->end();
         }
+
+        return $tree;
     }
 }


### PR DESCRIPTION
This PR fixed log message: ```The "Symfony\Component\Config\Definition\Builder\TreeBuilder::root()" method called for the "intaro_postgres_search" configuration is deprecated since Symfony 4.3, pass the root name to the constructor instead.```